### PR TITLE
Some more mispellings, tested and working

### DIFF
--- a/chat_filter.js
+++ b/chat_filter.js
@@ -40,8 +40,8 @@ var BLOCKED_WORDS = [
 		, "lrfy", "seft", "kleft", "l3ft", "lfte", "etfl", "lleft"
     
 	//    "right" misspellings
-	, "riight", "rightr", "roght", "righ", "ight", "righr", "rigt" "dright", "girht", "rihy"
-		, "eifght", "rig", "tight", "rihtg", "rihgt"
+	, "riight", "rightr", "roght", "righ", "ight", "righr", "rigt", "dright", "girht", "rihy"
+		, "eifght", "rig", "tight", "rihtg", "rihgt", "rigth"
 	
 	//    "start" misspellings
     , "atart", "strt", "strat", "starp"
@@ -56,8 +56,8 @@ var BLOCKED_WORDS = [
 		, "deomcracy", "democracydemocracy", "democracyvdemocracy", "democracu", "domecracy"
     
 	//Other spam.
-    , "communism", "oligarchy", "bureaucracy", "monarchy", "alt f4", "alt+f4", "exit", "enter"
-		, "***"
+    , "communism", "oligarchy", "bureaucracy", "monarchy", "alt f4", "alt\\+f4", "exit", "enter"
+		, "\\*\\*\\*"
 ];
 
 var MINIMUM_MESSAGE_LENGTH = 3; //For Kappas and other short messages.


### PR DESCRIPTION
Some more mispellings, forked from when this was at 40 commits.
Tested it a little bit, and seems to work fine, even the escaping of special char spam.

Also has some rather heavy modifications to the visual structure of the blocked words list. Now it fits on windows scaled to only fit 100 columns.
Also moved end-line commas to beginning of next row; looks rather ugly, but honestly far more comfortable structure to use when adding many words.
