### PR TITLE
Filter in insert_with_lock_in, fix scrolling. Fix init.

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -317,13 +317,14 @@ var initialize_filter = function(){
 $(function(){
     initialize_ui();
     
-    if(myWindow.CurrentChat) {
-        initialize_filter();
-    } else {
-        $(myWindow).on("load", function(){
-            initialize_filter();
-        });
-    }
+	//Instead of testing for the existence of CurrentChat, check if the spinner is gone.
+	var chatLoadedCheck = myWindow.setInterval(function () {
+		if($("#chat_loading_spinner").css('display') == 'none'){
+			myWindow.clearInterval(chatLoadedCheck);
+			initialize_filter();
+		}
+	}, 100);
+	
 });
     
 }());


### PR DESCRIPTION
I got tired of messages getting pushed out of the queue by spam, so I
decided to change things up and hook in to insert_with_lock_in instead.
Now the line counter is based on the currently displayed messages and
scrolling works properly.

Please give this code a shot and let me know what you think!
