### PR TITLE
colored @username, url duplicate filter, one-word filter, buttons

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -63,7 +63,8 @@ var BLOCKED_WORDS = [
 ];
 
 var BLOCKED_URLS = [
-    "nakedjenna", "bit.ly", "bitly", "tinyurl", "teespring", "youtube.com/user", "naked-riley"
+    "nakedjenna", "bit.ly", "bitly", "tinyurl", "teespring", "youtube.com/user", "naked-riley",
+    "twitch.tv", "ow.ly", "steam-games-free", "free-steam-games", "cheap games"
 ];
 
 var MINIMUM_MESSAGE_LENGTH = 3; // For Kappas and other short messages.


### PR DESCRIPTION
Fixed the problems I had with url duplicates... mostly. 'Surprisingly' the no-space sentences fixed themselves when I decided that urls are identical if their '.com/path?query=' are identical (skip last query value, and whats before the last '.' to ensure that what is between the url's doesnt matter).

I would doubt that performance really is a problem for a chat like this, but if it is, the regexp should be possible to shorten by removing the parts that is outside its paranthesis. Moving the url check further down the spam function should probably also improve performance, since the heavy regexp stuff is currently the first stuff that is done.
Performance _does_ seem to have been affected when the script loads and a few hundred messages already been received.

Also made sure that the change from commit #81 was added, although I did that manually because I'm not very used to giyhub yet and couldnt figure out how to update a fork.

The one-word filter and url duplicate filter also have buttons now, with them turned off and on by default respectivelly.
