### PR TITLE
Separate filter into toggleable features

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -269,15 +269,7 @@ var initialize_ui = function(){
 
     //TODO: #chat_line_list li.fromjtv
 
-    var customCssParts = [
-        "#TppControlPanel {",
-            "background-color:white;",
-            "position:absolute;",
-            "top:0px;",
-            "left:0px;",
-            "z-index:999;",
-        "}"
-    ];
+    var customCssParts = [];
     filters.forEach(function(filter){
         var cls = filter.name;
         customCssParts.push('#chat_line_list.'+cls+' li.'+cls+'{display:none}');
@@ -320,8 +312,17 @@ var initialize_ui = function(){
         
     });
     
+    var toggleControlPanel = document.createElement("button");
+    toggleControlPanel.appendChild(document.createTextNode("Chat Filter settings"));
+    $(toggleControlPanel).click(function(){
+      $(controlPanel).toggleClass("hidden");
+    });
+    
+    var controls = document.getElementById("controls");
+    
     document.body.appendChild(customStyles);
-    document.body.appendChild(controlPanel);
+    controls.appendChild(toggleControlPanel);
+    controls.appendChild(controlPanel);
 };
 
 // --- Main ---


### PR DESCRIPTION
I refactored the code so that instead of a single spam filter now we have many spam filters that we can toggle via some checkboxes.

I also took the opportunity to refactor the code. The biggest one is that the `insert_with_lock_in` override is a bit simpler now. Instead of keeping track of how many of watch type of message we have, I ended up changing the buffer cleanup to prioritize deleting hidden messages first.

There are still some minor things that need to be adjusted before merging this though, so feedback is welcome:
- Need to find a permanent place to put the control panel. Being in the top left like that is temporary.
- I got rid of some spam filtering (oligarchy, helix, etc). I dont see them too often but maybe we should add an extra filter for that.
- All the options do filtering; None modify the messages (replace caps with lowercase, do special colloring, etc). However, I think doing only one thing keeps things simple.
- Currently the URL filter blocks every single URL. Its going to need a whitelist for some useful sites.

This PR is a bit related to #17 and https://github.com/jpgohlke/twitch-chat-filter/pull/25
