### PR TITLE
Add "wait" command to array of blocked words

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -57,7 +57,7 @@
 
 var BLOCKED_WORDS = [
     //Standard Commands
-    "left", "right", "up", "down", "start", "select", "a", "b", "democracy", "anarchy",                                                
+    "left", "right", "up", "down", "start", "select", "a", "b", "democracy", "anarchy", "wait",                   
     //Other spam
     "oligarchy", "bureaucracy", "monarchy", "alt f4", "helix"
 ];


### PR DESCRIPTION
TPP added a new command recently, the "**wait**" command which only appears in democracy mode. We aren't currently filtering this in the chat so there a whole bunch of "waits" popping up right now in the talk section of the chat and making it hard to read things. I went ahead and added it to the array of blocked words as a quick fix. I tested it out and it works great.

If you want me to include a new minified version as part of this branch as well let me know and I'll do that.
