### PR TITLE
Fixed a display problem with the chat

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -353,7 +353,6 @@ var color_directed_messages = function( innerHTML, message ) {
 var convert_ALLCAPS = function( innerHTML, message ) {
 	if (message === message.toUpperCase()) {
 		var no_ALLCAPS = function(match, offset, string) {
-			console.log(match);
 			return match.toLowerCase();
 		}
 		
@@ -499,6 +498,22 @@ var initialize_ui = function(){
     document.body.appendChild(customStyles);
     controls.appendChild(toggleControlPanel);
     controls.appendChild(controlPanel);
+    
+    // adjust chat scroll height so that we can see the bottom of it, even with the extra buttons
+    function adjustChatElements() {
+        var el = $("#twitch_chat .js-chat-scroll");  // need to resize this
+        
+        if(adjustChatElements.baseHeight == undefined)  // first time
+            adjustChatElements.baseHeight = parseInt(el.css("bottom"));
+            
+        el.css("bottom", adjustChatElements.baseHeight + 
+            $("#TppControlPanel").height() + 
+            $(toggleControlPanel).height());
+    }
+    $(toggleControlPanel).click(adjustChatElements);
+    
+    // trigger initial resizing
+    adjustChatElements();
 };
 
 


### PR DESCRIPTION
most recent chat entries were cut off because of the addition of the control panel and the button.

![like this](https://f.cloud.github.com/assets/199185/2242647/be431b7e-9d0a-11e3-9e1c-747284ba4430.png)

Now with these fixes the chat should automatically resize to fit the space it is given.
