### PR TITLE
Better styling for updated Twitch chat.

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -290,6 +290,9 @@ $(function(){
 
 //Must wait until DOM load to do feature detection
 var NEW_TWITCH_CHAT = ($("button.viewers").length > 0);
+//Selectors
+var chatListSelector = (NEW_TWITCH_CHAT) ? '.chat-messages' : '#chat_line_list';
+var chatMessageSelector = (NEW_TWITCH_CHAT) ? '.message' : '.chat_line';
 
 //Filters have predicates that are called for every message
 //to determine whether it should get dropped or not
@@ -347,7 +350,7 @@ var stylers = [
   { name: 'TppConvertAllcaps',
     comment: "Lowercase-only mode",
     isActive: true,
-    element: (NEW_TWITCH_CHAT) ? '#chat' : '#chat_line_list',
+    element: chatListSelector,
     class: 'allcaps_filtered'
   },
 ];
@@ -381,8 +384,8 @@ function initialize_ui(){
     //TODO: #chat_line_list li.fromjtv
     var controlButton, controlPanel;
     var customCssParts = [
-        ".chat-messages .TppFiltered {display:none;}",
-        "#chat.allcaps_filtered span.message{text-transform:lowercase;}"
+        chatListSelector+" .TppFiltered {display:none;}",
+        chatListSelector+".allcaps_filtered "+chatMessageSelector+"{text-transform:lowercase;}"
     ];
     
     if(NEW_TWITCH_CHAT){
@@ -485,7 +488,7 @@ function update_chat_with_filter(){
 
     $((NEW_TWITCH_CHAT) ? '.chat-line' : '#chat_line_list li').each(function() {
         var chatLine = $(this);
-        var chatText = chatLine.find((NEW_TWITCH_CHAT) ? ".message" : ".chat_line").text().trim();
+        var chatText = chatLine.find(chatMessageSelector).text().trim();
 
         if(passes_active_filters(chatText)){
             chatLine.removeClass("TppFiltered");


### PR DESCRIPTION
I updated the UI to make use of the new CSS styles such as `chat-settings` and `chat-menu`. It now looks like this:
![](https://hostr.co/file/CUBlAt64f44v/TwitchChatFilter-UpdatedUI.png)

I also made it easier to add the different sections (hide, rewrite and style) through `add_section`, which then calls `add_option` on every option in the section.

I changed some `.after` and `.append` calls into `.insertAfter` and `.appendTo` so we can more easily work with the inserted elements as variables (instead of having to rely on IDs and querying them again).
