### PR TITLE
Detect which version of the chat we are using

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -480,7 +480,6 @@ function update_chat_with_filter(){
 }
 
 function initialize_filter(){
-    update_chat_with_filter();
     var original_insert_chat_line;
     
     function filtered_addMessage(info) {
@@ -494,10 +493,11 @@ function initialize_filter(){
         original_insert_chat_line = Room_proto.addMessage;
         Room_proto.addMessage = filtered_addMessage;
     }else{
-        CurrentChat = myWindow.CurrentChat;
-        original_insert_chat_line = CurrentChat.insert_chat_line;
-        CurrentChat.insert_chat_line = filtered_addMessage;
+        var Chat_proto = myWindow.Chat.prototype;
+        original_insert_chat_line = Chat_proto.insert_chat_line;
+        Chat_proto.insert_chat_line = filtered_addMessage;
     }
+    update_chat_with_filter();
 }
 
 $(function(){


### PR DESCRIPTION
The new chat filter doesn't work for the old chat. Ideally we would have
one single filter for both, but for now we are going to have to live
with this hacky solution. I didn't spend much time trying to eliminate
repetition. I'm sure the code could be consolidated some.

We should test for the new chat with a DOM element, and I don't
have the new chat, so I picked button.viewers. Not sure if that is the
best choice but that's one of the few unique things I see in the new
filter.

Addresses part of issue #71
