### PR TITLE
Fix feature detection for greasemonkey

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -127,7 +127,6 @@ try{
 var $ = myWindow.jQuery;
 var chat_is_loaded = false;
 
-var NEW_TWITCH_CHAT = ($("button.viewers").length > 0) ? true : false;
 // --- Filtering predicates ---
 
 // Adapted from https://gist.github.com/andrei-m/982927
@@ -284,6 +283,11 @@ function convert_copy_paste(message){
 }
 
 // --- Filtering ---
+
+$(function(){
+
+//Must wait until DOM load to do feature detection
+var NEW_TWITCH_CHAT = ($("button.viewers").length > 0);
 
 //Filters have predicates that are called for every message
 //to determine whether it should get dropped or not
@@ -486,7 +490,7 @@ function initialize_filter(){
         if(!passes_active_filters(info.message)){ return false }
         info.message = rewrite_with_active_rewriters(info.message);
         return original_insert_chat_line.apply(this, arguments);
-    };
+    }
     
     if(NEW_TWITCH_CHAT){
         var Room_proto = myWindow.App.Room.prototype;
@@ -500,21 +504,21 @@ function initialize_filter(){
     update_chat_with_filter();
 }
 
-$(function(){
-    //Checking for the spinner being gone is a more reliable way to chack
-    //if the CurrentChat is fully loaded.
-    function initialize_all(){
-        chat_is_loaded = true;
-        clearInterval(chatLoadedCheck);
-        initialize_ui();
-        initialize_filter();
-    }
-    var chatLoadedCheck = setInterval(function () {
-        if(NEW_TWITCH_CHAT && $(".loading-mask").length <= 0)
-            initialize_all();
-        else if($("#chat_loading_spinner").css('display') == 'none')
-            initialize_all();
-    }, 100);
+
+//Checking for the spinner being gone is a more reliable way to chack
+//if the CurrentChat is fully loaded.
+function initialize_all(){
+    chat_is_loaded = true;
+    clearInterval(chatLoadedCheck);
+    initialize_ui();
+    initialize_filter();
+}
+var chatLoadedCheck = setInterval(function () {
+    if(NEW_TWITCH_CHAT && $(".loading-mask").length <= 0)
+        initialize_all();
+    else if($("#chat_loading_spinner").css('display') == 'none')
+        initialize_all();
+}, 100);
 
 });
 


### PR DESCRIPTION
Greasemonkey was incorrectly treating new chat users as old chat users,
causing it to get stuck in the "loading" forever. This is because we were
trying to use DOM operations for feature detection before the DOM was ready.

I not sure checking for App.Room is the best way to do feature detection.
An alternative would be moving all the code inside the `$` callback but
I'm not a big fan of that because its harder to debug inner functions.
