### PR TITLE
Stop waiting for the chat spinner

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -128,7 +128,6 @@ try{
 }
 
 var $ = myWindow.jQuery;
-var chat_is_loaded = false;
 
 // --- Filtering predicates ---
 
@@ -472,7 +471,6 @@ function initialize_ui(){
 // --- Main ---
 
 function update_chat_with_filter(){
-    if(!chat_is_loaded) return;
 
     $((NEW_TWITCH_CHAT) ? '.chat-line' : '#chat_line_list li').each(function() {
         var chatLine = $(this);
@@ -508,20 +506,9 @@ function initialize_filter(){
 }
 
 
-//Checking for the spinner being gone is a more reliable way to chack
-//if the CurrentChat is fully loaded.
-function initialize_all(){
-    chat_is_loaded = true;
-    clearInterval(chatLoadedCheck);
-    initialize_ui();
-    initialize_filter();
-}
-var chatLoadedCheck = setInterval(function () {
-    if(NEW_TWITCH_CHAT && $(".loading-mask").length <= 0)
-        initialize_all();
-    else if($("#chat_loading_spinner").css('display') == 'none')
-        initialize_all();
-}, 100);
+initialize_ui();
+initialize_filter();
+
 
 });
 


### PR DESCRIPTION
Now that we are overriding the Chat prototype instead of the chat objects
themselves we don't need to wait until the chat object is created in order to
override it. This makes the script seem more responsive and also simplifies the code
a bit (one less thing to worry about when it comes to new chat compatibility)

The chat_is_loaded variables was kind of pointless too. We can't click on
any of the configuration buttons before the loading spinner goes away.
