### PR TITLE
3 new options

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -3,20 +3,9 @@
 // @namespace   https://github.com/jpgohlke/twitch-chat-filter
 // @description Hide input commands from the chat.
 
-<<<<<<< HEAD
 // @include     /^https?://(www|beta)\.twitch\.tv\/twitchplayspokemon(/(chat.*)?)?$/
 
-// @version     1.91
-=======
-// @include     http://www.twitch.tv/twitchplayspokemon
-// @include     http://www.twitch.tv/twitchplayspokemon/
-// @include     http://www.twitch.tv/chat/embed?channel=twitchplayspokemon&popout_chat=true
-// @include     http://beta.twitch.tv/twitchplayspokemon
-// @include     http://beta.twitch.tv/twitchplayspokemon/
-// @include     http://beta.twitch.tv/twitchplayspokemon/chat?popout=&secret=safe
-
-// @version     2.0
->>>>>>> gh-pages
+// @version     2.1
 // @updateURL   http://jpgohlke.github.io/twitch-chat-filter/chat_filter.user.js
 // @grant       unsafeWindow
 // ==/UserScript==
@@ -359,15 +348,12 @@ var filters = [
     predicate: message_is_cyrillic
   },
   
-<<<<<<< HEAD
   { name: 'TppFilterLong',
     comment: 'Overly long messages',
     isActive: false,
     predicate: message_is_too_long
   },
   
-=======
->>>>>>> gh-pages
   { name: 'TppFilterCustom',
     comment: 'Add custom filter',
     isActive: false,
@@ -458,11 +444,8 @@ function initialize_ui(){
     var customCssParts = [
         chatListSelector+" .TppFiltered {display:none;}",
         chatListSelector+".allcaps_filtered "+chatMessageSelector+"{text-transform:lowercase;}",
-<<<<<<< HEAD
         chatListSelector+".hide_emoticons "+chatMessageSelector+" .emoticon{display:none !important;}",
         chatListSelector+".disable_colors "+chatMessageSelector+"{color: #000 !important;}",
-=======
->>>>>>> gh-pages
         ".custom_list_menu {background: #aaa; border:1px solid #000; position: absolute; right: 2px; bottom: 2px; padding: 10px; display: none;}",
         "#chat_filter_dropmenu a {color: #00f;}",
         ".tpp-custom-filter {position: relative;}",


### PR DESCRIPTION
Added 3 options:
- Uncolor messages, colored messages stand out to me and mostly they are annoying.
- Remove emoticons: There has been a flood of emoticons recently, removing them makes the chat much more readable
- Filter overly long messages: Filters out messages that (approximately) cover more than 4 lines
- Also includes the userscript fix (#85)

I don't understand why it lists all commits since March 3rd, in "files changed" it only shows relevant changes (from today) (and a random part of the custom filter (line 398-404)...?)
I suppose this is because gh-pages was last updated without merging from master?
