### PR TITLE
Better time limit handling

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -867,7 +867,7 @@ function check_for_time_limit(admin_text){
             update_button();
             renew_interval();
             
-            return "Your last message coulnd not be sent. Please try again shortly.";
+            return "Your last message could not be sent. Please try again shortly.";
         }
     }
     if(/slow mode and you are sending/.test(admin_text)){


### PR DESCRIPTION
- Don't assume slow mode on default (currently, you start with the 20 second timer when there is a 5 sec limit and ther eis no slow mode message)
- Adjust time limits when last message could not be sent (when time limits are wrong or the 30 second repeated message timer is actually a 35 second timer)
- Added handling for when user is banned (Happens more often than you think)
- Alter some admin messages to be more meaningful with the timer, remove slow mode messages if slow mode time limit wasn't changed.
