### PR TITLE
Old Twitch embedded chat window URLs in @include

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -3,7 +3,7 @@
 // @namespace   https://github.com/jpgohlke/twitch-chat-filter
 // @description Hide input commands from the chat.
 
-// @include     /^https?://(www|beta)\.twitch\.tv\/twitchplayspokemon(/(chat.*)?)?$/
+// @include     /^https?://(www|beta)\.twitch\.tv\/(twitchplayspokemon(/(chat.*)?)?|chat\/.*channel=twitchplayspokemon.*)$/
 
 // @version     2.2
 // @updateURL   http://jpgohlke.github.io/twitch-chat-filter/chat_filter.user.js


### PR DESCRIPTION
Allow filter to run when TPP chat is in an old-style embedded chat frame, like on multitwitch.tv
