### PR TITLE
Make the command filter accept more separators

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -189,7 +189,7 @@ function word_is_command(word){
 function message_is_command(message, sender){
     message = message.toLowerCase();
 
-    var segments = message.split(/[\d\+\s]+/);
+    var segments = message.match(/[A-Za-z]+/g);
 
     for(var i=0; i<segments.length; i++){
         var segment = segments[i];


### PR DESCRIPTION
It now accepts any non-letter character as a command separator.
This is needed because the new democracy mode apparently also
accepts commas as command separator (in addition to the numbers
and "+"s we were already accepting)
