### PR TITLE
Fix "custom banlist" toggle not refiltering old messages

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -914,14 +914,13 @@ function rewrite_with_active_rewriters(message){
 }
 
 add_initializer(function(){
-    // Apply filters to existing messages
-    // (Cannot do the same with rewriters)
-    forEach(TCF_FILTERS, function(setting){
+    forEach(TCF_SETTINGS_LIST, function(setting){
         setting.observe(function(){
             $(CHAT_LINE_SELECTOR).each(function(){
                 var chatLine = $(this);
                 var chatText = chatLine.find(CHAT_MESSAGE_SELECTOR).text().trim();
                 chatLine.toggle( passes_active_filters(chatText) );
+                //Sadly, we can't apply rewriters to old messages because they are in HTML format.
             });
         });
     });


### PR DESCRIPTION
Currently, old messages get refiltered when we add or remove a word
to the banlist but they do not get refiltered if we toggle the banlist
on and off (future messages are filtered correctly though)
