### PR TITLE
Add a scrollbar to the settings menu

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -741,6 +741,18 @@ add_initializer(function(){
 
     var settingsMenu = $(SETTINGS_MENU_SELECTOR);
 
+    // Add a scrollbar to the settings menu if its too long
+    var chat_room = $(CHAT_ROOM_SELECTOR);
+    settingsMenu.css("overflow-y", "auto");
+    function updateMenuHeight(){
+        settingsMenu.css("max-height", 0.9 * chat_room.height());
+    }
+    updateMenuHeight();
+    $(window).resize(function(){
+        updateMenuHeight();
+    });
+
+
     function addBooleanSetting(menuSection, option){
     
         menuSection.append(


### PR DESCRIPTION
Fixes #124

I would like to try out a simple scrollbar first before going for more complicated options. I want to avoid needing to use a separate button again (its too much trouble to create space for it and it breaks all the time) and I think collapsible sections might be hard to create easy-to-use collapsible sections.
