### PR TITLE
Removed broken fallback. Fixes #152

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -1200,21 +1200,6 @@ add_initializer(function(){
 
 $(function(){
 
-// Fallback to old script if new chat is not supported.
-if($("button.viewers").length <= 0){
-    //The user is not using the latest version of Twitch chat;
-    //Fallback to an older version of the filtering script.
-    
-    //I don't know if any users actuall still have the old chat.
-    //This code is here just due to paranoia...
-    
-    var tag = document.createElement('script');
-    tag.type = 'text/javascript';
-    tag.src = 'http://jpgohlke.github.io/twitch-chat-filter/chat_filter_old.user.js';
-    document.body.appendChild(tag);
-    throw new Error('Falling back to old filter script');
-}
-
 run_initializers();
 load_settings();
 


### PR DESCRIPTION
With Twitch's UI change of today, the Viewers List button is now an `a.button > svg.svg-viewers` and no longer matches `buttons.viewers` which triggers the load of a fallback script. It appears like that fallback script URL was never working in the first place, and thus nothing is loaded and everything breaks.

The script actually _works fine_ with the new UI, there's no need for a fallback. Therefore, I suggest we simply remove the fallback and bring it back later if needed (preferably _with_ an actual fallback script on the `gh-pages`).
