### PR TITLE
Fix for Ember rewrite.

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -98,6 +98,8 @@
 }(function(){
 "use strict";
 
+if (!window.$) { return; }
+
 var TCF_VERSION = "2.9" ;
 var TCF_INFO = "TPP Chat Filter version " + TCF_VERSION + " loaded. Please report bugs and suggestions to https://github.com/jpgohlke/twitch-chat-filter";
 

--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -1220,7 +1220,8 @@ add_setting({
 // ============================
 
 add_initializer(function(){
-    var Room_proto = App.Room.prototype;
+
+    var Room_proto = require("web-client/models/room")["default"].prototype;
 
     var original_addMessage = Room_proto.addMessage;
     Room_proto.addMessage = function(info) {
@@ -1246,13 +1247,18 @@ add_initializer(function(){
 // Main
 // ============================
 
-$(function(){
+// Initialize when chat view is inserted
+var ChatView_proto = require("web-client/views/chat")["default"].prototype;
+var original_didInsertElement = ChatView_proto.didInsertElement;
+ChatView_proto.didInsertElement = function(){
+
+original_didInsertElement && original_didInsertElement.apply(this, arguments);
 
 run_initializers();
 load_settings();
 
 console.log(TCF_INFO);
 
-});
+};
 
 }));

--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -1037,6 +1037,8 @@ add_initializer(function(){
 
 function matches_filters(message, from){
     var matches = {};
+    message = message || "";
+    from = from || "";
     forEach(TCF_FILTERS, function(setting){
         matches[setting.name] = setting.message_filter(message, from);
     });
@@ -1044,7 +1046,8 @@ function matches_filters(message, from){
 }
 
 function rewrite_with_active_rewriters(message, from){
-    var newMessage = message;
+    var newMessage = message || "";
+    from = from || "";
     forEach(TCF_REWRITERS, function(setting){
         if(setting.getValue()){
             newMessage = (setting.message_rewriter(newMessage, from) || newMessage);

--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -955,7 +955,7 @@ add_initializer(function(){
     }
 
     function addMenuSection(name){
-        $('<div class="chat-menu-header"/>')
+        $('<div class="list-header"/>')
             .text(name)
             .appendTo(settingsMenu);
         

--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -1094,6 +1094,7 @@ add_initializer(function(){
         forEach(TCF_FILTERS, function(setting) {
             chatLine.toggleClass(setting.name, setting.message_filter(message, from));
         });
+        //Sadly, we can't apply rewriters to old messages because they are in HTML format.
     });
 });
 

--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -1260,8 +1260,8 @@ add_initializer(function(){
         if(info.style === "admin"){
             if(!update_slowmode_with_admin_message(info.message)){ return false }
         }else{
-            // Apply rewriters to future messages
-            info.message = rewrite_with_active_rewriters(info.message, info.from);
+            // TODO Apply rewriters to future messages
+            // info.message = rewrite_with_active_rewriters(info.message, info.from);
         }
         
         return original_addMessage.apply(this, arguments);


### PR DESCRIPTION
Twitch has rewritten their JavaScript code using the [Ember](http://emberjs.com/). This broke the script, since the chat room class is no longer in `window.App.Room` (see #164).

This fix seems to work, but it needs some more polish and more testing. Most notably, after leaving the stream page open for a while, the chat stops working and the console gets filled with errors.

Firefox console:
```
TypeError: n is null (emberapp.js:5:19753)
Stacktrace:
p@http://web-cdn.ttvnw.net//emberapp.js:11:26443
d.after@http://web-cdn.ttvnw.net//emberapp.js:4:22468
g@http://web-cdn.ttvnw.net//emberapp.js:10:28510
.ensureChildrenAreInDOM@http://web-cdn.ttvnw.net//emberapp.js:10:31566
M<._ensureChildrenAreInDOM@http://web-cdn.ttvnw.net//emberapp.js:10:30895
n.prototype.invokeWithOnError@http://web-cdn.ttvnw.net//emberapp.js:2:18471
n.prototype.flush@http://web-cdn.ttvnw.net//emberapp.js:2:18903
i.prototype.end@http://web-cdn.ttvnw.net//emberapp.js:2:14475
o/e._autorun<@http://web-cdn.ttvnw.net//emberapp.js:2:13288
```

Chrome console:
```
 Assertion failed: TypeError: Cannot read property 'nextSibling' of null {stack: (...), message: "Cannot read property 'nextSibling' of null"} (emberapp-67477e4644559862e1ed43945c743b40.js:5)
   n.function.n.apply.r (emberapp-67477e4644559862e1ed43945c743b40.js:14)
   i.onerror (emberapp-67477e4644559862e1ed43945c743b40.js:2)
   n.invokeWithOnError (emberapp-67477e4644559862e1ed43945c743b40.js:2)
   n.flush (emberapp-67477e4644559862e1ed43945c743b40.js:2)
   i.end (emberapp-67477e4644559862e1ed43945c743b40.js:2)
   (anonymous function)
```

My guess is that an element gets deleted which shouldn't have been deleted... but I have no idea where to start.