### PR TITLE
Filter commands from military input mode

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -377,7 +377,8 @@ var TPP_COMMANDS = [
     "start", "select",
     "a", "b",
     "l", "r",
-    "democracy", "anarchy", "wait"
+    "democracy", "anarchy", "wait",
+    "move", "switch", "run", "item"
 ];
 
 var EDIT_DISTANCE_TRESHOLD = 2;
@@ -429,6 +430,9 @@ function word_is_command(word){
 function message_is_command(message){
     //Touch pad coordinates
     if(/^([0-9]+),([0-9]+)$/.test(message.replace(/\s/g, ""))){ return true }
+
+    // Military mode: item command - https://redd.it/45t454/
+    if(/^\s*item[a-z0-9]*\s*$/i.test(message)){ return true }
 
     // Button presses
     return all(message.split(/\s+/), function(word){


### PR DESCRIPTION
As reported in #172, the Crystal 251 run introduces [new "military mode" inputs](https://www.reddit.com/r/twitchplayspokemon/comments/45t454/military_mode/):
> move(1-4)
> switch(1-6)
> run
> item(1-254) [e.g. poke balls, master balls, etc]
> item(1-254)p(1-6) [e.g. revives, antidotes]
> item(1-254)p(1-6)m(1-4) [e.g. max ethers]

This PR adds these new commands to the commands filter.