### PR TITLE
Fix messages not appearing as filtered

### DIFF
--- a/chat_filter.user.js
+++ b/chat_filter.user.js
@@ -54,6 +54,7 @@
  *     /u/anonveggy
  *     /u/rctgamer3
  *     /u/BBQCalculator
+ *     /u/Soulweaver91
  */
 
 
@@ -1066,7 +1067,13 @@ add_initializer(function(){
     forEach(TCF_FILTERS, function(setting){
         var filter = setting.name;
         var toggle = setting.name + "Hidden";
-        customCSS.push(CHAT_ROOM_SELECTOR+"."+toggle+" "+CHAT_LINE_SELECTOR+"."+filter+"{display:none}");
+        
+        // Keep both the old and the new version for maximized compatibility.
+        // (In theory, only the newer rule should be necessary, but you never know.)
+        customCSS.push(
+            CHAT_ROOM_SELECTOR + "." + toggle + " " + CHAT_LINE_SELECTOR + "." + filter + ',' +
+            CHAT_ROOM_SELECTOR + "." + toggle + " ." + filter + " " + CHAT_LINE_SELECTOR +
+            "{display:none}");
 
         setting.observe(function(){
             $(CHAT_ROOM_SELECTOR).toggleClass(toggle, setting.getValue());


### PR DESCRIPTION
Recently, the filter stopped working for me. It was an easy fix once I looked into it, though. Basically, the HTML structure of the messages in the chat was altered so that the generated CSS didn't match the messages anymore. The new structure (after running the message through the filters) that the commit also takes into account is as follows:

```html
<div class="ember-view TppFilterCommand TppFilterSmall" id="ember6894">
  <li class="ember-view message-line chat-line" id="ember6895">
    <div class="indicator"></div>
    <span class="timestamp float-left">7:11</span>
    <span class="badges float-left"></span>
    <span class="from" style="color:#B22222">Danneborger</span>
    <span class="colon">:</span>
    <span class="message" style="">down</span>
  </li>
</div>
```

They might be running some kind of limited testing on only a subset of users based on the lack of comments on the breakage, apart from [this one](https://www.reddit.com/r/twitchplayspokemon/comments/4bepii/problems_with_the_chat_filter/) which might or might not be related. To account for that, I also left the old CSS rule in place.